### PR TITLE
unread_announcementsのindexは逆のほうが効きそう

### DIFF
--- a/sql/1_schema.sql
+++ b/sql/1_schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE `unread_announcements`
     `announcement_id` CHAR(26)   NOT NULL,
     `user_id`         CHAR(26)   NOT NULL,
     `is_deleted`      TINYINT(1) NOT NULL DEFAULT false,
-    PRIMARY KEY (`announcement_id`, `user_id`),
+    PRIMARY KEY (`user_id`, `announcement_id`),
     CONSTRAINT FK_unread_announcements_announcement_id FOREIGN KEY (`announcement_id`) REFERENCES `announcements` (`id`),
     CONSTRAINT FK_unread_announcements_user_id FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 );


### PR DESCRIPTION
```
# Query 10: 145.38 QPS, 0.23x concurrency, ID 0x1F21068CC7652980263E82315944F5FD at byte 142760006
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.03
# Time range: 2023-09-02T07:56:03 to 2023-09-02T07:57:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          3   11921
# Exec time      0     18s    89us   219ms     2ms     3ms     7ms   490us
# Lock time      1    29ms       0    12ms     2us     1us   102us     1us
# Rows sent      1  11.64k       1       1       1       1       0       1
# Rows examine   6   1.41M       0     300  123.95  192.76   69.39  124.25
# Query size     2   1.26M     111     111     111     111       0     111
# String:
# Databases    isucholar
# Hosts        ip-172-31-13-72.ap-northeast-1.compute.inter...
# Users        isucon
# Query_time distribution
#   1us
#  10us  #
# 100us  ################################################################
#   1ms  ###
#  10ms  #
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isucholar` LIKE 'unread_announcements'\G
#    SHOW CREATE TABLE `isucholar`.`unread_announcements`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) FROM `unread_announcements` WHERE `user_id` = '01FF6J8XQWTTBP35N007BZZYMD' AND NOT `is_deleted`\G
```

user_idで検索をかけるクエリが多く、逆のほうがうまく効く気がする