### PR TITLE
n回目のGPAキャッシュチャレンジ

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -102,7 +102,7 @@ func main() {
 	go func() {
 		// 1秒ごとにGPAsを更新する
 		for {
-			gpasMutex.Lock()
+			var newGpas []float64
 			query := `
 WITH student_credits AS (
     SELECT users.id AS user_id, SUM(courses.credit) AS total_credits
@@ -122,9 +122,11 @@ student_scores AS (
 SELECT (student_scores.weighted_score / student_credits.total_credits / 100) AS GPA
 FROM student_credits
 INNER JOIN student_scores ON student_credits.user_id = student_scores.user_id;`
-			if err := db.Select(&gpas, query); err != nil {
+			if err := db.Select(&newGpas, query); err != nil {
 				log.Println("error:", err)
 			}
+			gpasMutex.Lock()
+			gpas = newGpas
 			gpasMutex.Unlock()
 			time.Sleep(1 * time.Second)
 		}


### PR DESCRIPTION
refs #17 

やはりGPA求める辺りが致命的に重い

```
Top 20 Sort By Total
Count     Total    Mean  Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max    2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
21966  2311.692  0.1052  0.1057  0.000  0.077  0.200  0.272  0.522  1.940  21963    0    3    0     8781857         21        399        612  GET /api/announcements/{announcement_id}
20714  1858.688  0.0897  0.0971  0.000  0.061  0.189  0.254  0.465  2.127  20709    0    5    0   472494072         14      22810    1189693  GET /api/courses/{course_id}/classes
  255  1159.825  4.5483  1.4032  0.000  5.000  5.001  5.001  5.002  5.002     24    0  231    0      488116          0       1914      31743  GET /api/users/me/grades HTTP/2.0
11597  1104.606  0.0952  0.1052  0.000  0.066  0.191  0.258  0.515  1.743  11596    0    1    0    40882750         22       3525       4146  GET /api/announcements HTTP/2.0
12178  1048.817  0.0861  0.0750  0.000  0.069  0.158  0.200  0.331  1.741  12175    0    3    0          95          0          0         42  POST /api/courses/{course_id}/classes/{class_id}/assignments
 8659   730.683  0.0844  0.0744  0.000  0.068  0.158  0.200  0.324  1.648   8650    0    9    0       52010          0          6         42  POST /api/courses/{course_id}/classes
 1088   316.353  0.2908  0.2498  0.000  0.220  0.698  0.816  1.006  1.504   1084    0    4    0          93          0          0         34  PUT /api/courses/{course_id}/classes/{class_id}/assignments/scores
  584   266.643  0.4566  0.4246  0.000  0.364  0.993  1.212  1.862  2.912    583    0    1    0     1118246          3       1914       2790  GET /api/users/me/courses HTTP/2.0
 1224   216.507  0.1769  0.1576  0.000  0.132  0.420  0.522  0.673  0.834   1221    0    3    0          60          0          0         23  POST /api/announcements HTTP/2.0
 1961   170.285  0.0868  0.0952  0.001  0.061  0.184  0.245  0.427  1.178   1961    0    0    0     6897134        202       3517       4102  GET /api/announcements?page={page} HTTP/2.0
  585   113.818  0.1946  0.1575  0.000  0.147  0.426  0.534  0.746  1.361    583    0    2    0         268          0          0        246  PUT /api/users/me/courses HTTP/2.0
 1792    74.329  0.0415  0.0674  0.000  0.023  0.096  0.133  0.249  1.078   1791    0    1    0     7556623          3       4216       8065  GET /api/courses?*
  712    33.407  0.0469  0.0624  0.000  0.026  0.110  0.155  0.251  0.730    711    0    1    0       40327         22         56         63  GET /api/users/me HTTP/2.0
  618    30.096  0.0487  0.0923  0.000  0.026  0.103  0.163  0.365  1.372    613    0    5    0       22196         20         35         43  POST /api/courses HTTP/2.0
  474    30.026  0.0633  0.0957  0.000  0.039  0.142  0.189  0.391  1.301    471    0    3    0          60          0          0         23  PUT /api/courses/{course_id}/status
  585    20.556  0.0351  0.0491  0.000  0.020  0.082  0.129  0.208  0.671    583    0    2    0      219278         15        374        423  GET /api/courses/<course_id> HTTP/2.0
  198     5.152  0.0260  0.0355  0.001  0.019  0.050  0.080  0.178  0.337    195    0    3    0          78          0          0         26  POST /login HTTP/2.0
  117     0.963  0.0082  0.0053  0.002  0.006  0.015  0.019  0.022  0.039    117    0    0    0    53861652     460356     460356     460356  GET /_nuxt/app.js HTTP/2.0
    2     0.926  0.4630  0.0080  0.455  0.471  0.471  0.471  0.471  0.471      2    0    0    0          36         18         18         18  POST /initialize HTTP/2.0
  117     0.860  0.0074  0.0058  0.000  0.005  0.015  0.019  0.022  0.039    117    0    0    0      178308       1524       1524       1524  GET /_nuxt/runtime.js HTTP/2.0
```