### PR TITLE
fix:setMaxIdleConnsをいっぱいまで使えるようにする

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -62,9 +62,11 @@ func main() {
 
 	db, _ := GetDB(false)
 	db.SetMaxOpenConns(100)
+	db.SetMaxIdleConns(100)
 
 	db2, _ := GetDB2(false)
 	db2.SetMaxOpenConns(100)
+	db2.SetMaxIdleConns(100)
 
 	h := &handlers{
 		DB:  db,


### PR DESCRIPTION
#26 

```
06:04:45.993777 score: 118700 (= 118700 - 0) : passed
06:04:45.993783 deductionCount: 0, timeoutCount: 22
06:04:45.993785 raw score (118700) breakdown:
06:04:45.993789 SubmitAssignment    : 28529 回 (85587 点)
06:04:45.993791 GetAnnouncementList : 33113 回 (33113 点)
```

負荷上がったりメモリ使いすぎたりする変化は特に見当たらない・・
s1(app)
<img width="1283" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/69ffc564-adc3-4889-bb60-5adb81733325">
<img width="1284" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/6f1e7b9d-077c-4535-8ff5-48adbfc06cd3">
s2
<img width="979" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/f6dfb4dd-b23b-4c1e-95f9-09edd468ab6c">
<img width="930" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/f84651a5-0ce8-4248-adb4-b146ae422140">
s3
<img width="924" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/d09dc1ef-29f6-4ed7-aeb9-30b98d6e445f">
<img width="780" alt="image" src="https://github.com/cureseven/isucon-practice-20230902/assets/16860566/ee57415e-065c-46a3-a1fe-f48dca0f2448">
