### PR TITLE
講義の存在チェックをキャッシュした

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -1113,7 +1113,7 @@ func (h *handlers) GetClasses(c echo.Context) error {
 	courseID := c.Param("courseID")
 
 	var count int
-	if err := h.DB.Get(&count, "SELECT COUNT(*) FROM `courses` WHERE `id` = ?", courseID); err != nil {
+	if err := h.DB.Get(&count, "SELECT 1 FROM `courses` WHERE `id` = ? LIMIT 1", courseID); err != nil {
 		c.Logger().Error(err)
 		return c.NoContent(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
```
Top 20 Sort By Total
Count     Total    Mean  Stddev    Min  P50.0  P90.0  P95.0  P99.0    Max    2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
29668  4718.661  0.1590  0.2514  0.000  0.071  0.405  0.643  1.276  4.127  29663    0    5    0   669234910         14      22557    1190003  GET /api/courses/{course_id}/classes
17628  3442.575  0.1953  0.2276  0.000  0.132  0.402  0.577  1.170  4.043  17625    0    3    0          51          0          0         22  POST /api/courses/{course_id}/classes/{class_id}/assignments
11949  2237.927  0.1873  0.2216  0.000  0.126  0.389  0.573  1.145  4.192  11940    0    9    0       56464          0          4         42  POST /api/courses/{course_id}/classes
33944  1765.935  0.0520  0.0707  0.000  0.026  0.141  0.199  0.341  0.737  33941    0    3    0    13778121         21        405        619  GET /api/announcements/{announcement_id}
 1004  1281.052  1.2759  1.3505  0.000  0.669  3.316  4.042  5.000  5.002    990    0   14    0      941783          0        938       2043  GET /api/users/me/courses HTTP/2.0
18392   953.274  0.0518  0.0655  0.000  0.026  0.143  0.192  0.292  0.487  18391    0    1    0    20226908         22       1099       2022  GET /api/announcements HTTP/2.0
 1230   571.334  0.4645  0.4000  0.000  0.367  1.029  1.256  1.641  2.954   1226    0    4    0          93          0          0         34  PUT /api/courses/{course_id}/classes/{class_id}/assignments/scores
  198   351.806  1.7768  1.1341  0.000  1.884  3.322  3.509  5.000  5.000    195    0    3    0     1349288          0       6814      11930  GET /api/users/me/grades HTTP/2.0
  959   348.368  0.3633  0.3101  0.000  0.291  0.768  1.015  1.366  2.177    957    0    2    0         268          0          0        246  PUT /api/users/me/courses HTTP/2.0
 3081   321.261  0.1043  0.1680  0.000  0.057  0.236  0.348  0.804  3.155   3080    0    1    0     3667823          3       1190       2007  GET /api/courses?*
 1329   244.190  0.1837  0.1980  0.000  0.113  0.456  0.599  0.837  1.141   1326    0    3    0          60          0          0         23  POST /api/announcements HTTP/2.0
 4569   152.148  0.0333  0.0561  0.000  0.009  0.101  0.150  0.270  0.467   4569    0    0    0     4998531        201       1094       2030  GET /api/announcements?page={page} HTTP/2.0
  788    98.532  0.1250  0.2109  0.000  0.056  0.335  0.472  1.154  2.195    787    0    1    0       44668         22         56         63  GET /api/users/me HTTP/2.0
 1006    94.260  0.0937  0.1830  0.000  0.044  0.199  0.308  0.981  2.380   1004    0    2    0      375386         15        373        505  GET /api/courses/<course_id> HTTP/2.0
  666    86.065  0.1292  0.2460  0.000  0.056  0.305  0.546  1.079  2.815    661    0    5    0       23924         20         35         43  POST /api/courses HTTP/2.0
  552    68.261  0.1237  0.1738  0.000  0.073  0.293  0.443  0.876  1.376    549    0    3    0          60          0          0         23  PUT /api/courses/{course_id}/status
  228    13.065  0.0573  0.1001  0.001  0.033  0.133  0.176  0.559  0.880    225    0    3    0          78          0          0         26  POST /login HTTP/2.0
    2     2.306  1.1530  0.0130  1.140  1.166  1.166  1.166  1.166  1.166      2    0    0    0          36         18         18         18  POST /initialize HTTP/2.0
  145     1.160  0.0080  0.0063  0.003  0.005  0.012  0.025  0.031  0.031    145    0    0    0    66751620     460356     460356     460356  GET /_nuxt/app.js HTTP/2.0
  145     1.013  0.0070  0.0067  0.000  0.005  0.011  0.025  0.031  0.031    145    0    0    0      220980       1524       1524       1524  GET /_nuxt/runtime.js HTTP/2.0
```